### PR TITLE
Add a help markdown file for the History Switcher modal

### DIFF
--- a/histories/selector_modal_switch.md
+++ b/histories/selector_modal_switch.md
@@ -1,0 +1,72 @@
+# [Help] How to use the History Selector
+
+This menu is the **Current History Selector** which allows you to change your **Current History**.
+
+## How to change your current or active history:
+1. **Find the history** you want to switch to:
+   - Scroll this menu to the bottom to load more histories and find the one you are looking for
+   - Find a history using the search field or the filter menu accessible through the toggle button next to the search field
+2. **Click anywhere on the History card** to switch to your desired history (the menu will be closed)
+3. You have now changed your **Current History** and it will be shown on the right panel
+
+:flashlight: Not enough histories? [Create](https://training.galaxyproject.org/training-material/faqs/galaxy/histories_create_new.html) new histories to see them in this menu.
+
+## :question: Help
+
+<details>
+<summary><b>What is my <i>Current History</i>?</b></summary>
+  The history currently displayed in the panel on the right is your <b>Current</b> history. This is the history that will populate and will be populated by tools and workflows.
+</details>
+
+<details>
+  <summary><b>Where do I find an exhaustive list of all of my histories?</b></summary>
+  An exhaustive list of all of your histories (and public histories or histories shared with you) can be found in the Histories list accessible by clicking on <b>User > Histories</b> in the masthead on the top, or by clicking on the <b>Histories</b> activity in the activity bar.
+</details>
+
+## Other operations in this menu
+
+On the bottom right corner of each history in this menu, you will find a couple buttons:
+1. The first `fa-columns`, titled _"Open in multi-view"_ will open that history in the [History Multiview](https://training.galaxyproject.org/training-material/faqs/galaxy/histories_side_by_side_view.html) which can be used to view and operate on multiple Galaxy histories side by side.
+2. The second `fa-list-alt`, titled _"Open in center panel"_ will open that history in the center, giving you more space to work with the history.
+
+:exclamation: **Neither of these operations will change your Current History**
+
+:flashlight: Perform other operations on your **Current History** by clicking the _History Options_ `fa-bars` button to the right of the button you clicked to open this menu.
+
+### Learn
+
+#### Galaxy Tutorials
+
+Tutorials from the _Galaxy Training Network_ that might help:
+
+[Understanding Galaxy history system](https://training.galaxyproject.org/training-material/topics/galaxy-interface/tutorials/history/tutorial.html)
+
+[Search the Galaxy Training Network](https://training.galaxyproject.org/training-material/search2)
+
+#### Galaxy FAQs
+
+<details>
+  <summary>Different dataset icons and their usage</summary>
+  display md https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_icons.html
+</details>
+
+<details>
+  <summary>Upload: Getting Data into Galaxy</summary>
+  display md https://help.galaxyproject.org/t/getting-data-into-galaxy/10868
+</details>
+
+<details>
+  <summary>Troubleshooting errors</summary>
+  display md https://training.galaxyproject.org/training-material/faqs/galaxy/analysis_troubleshooting.html
+</details>
+
+[See all Galaxy FAQs](https://training.galaxyproject.org/training-material/faqs/galaxy/)
+
+
+#### Help
+
+Get help navigating Galaxy by visiting the _Galaxy Help Forum_
+
+[Troubleshooting resources for errors or unexpected results](https://help.galaxyproject.org/docs?topic=42)
+
+[Visit the Galaxy Help forum](https://help.galaxyproject.org/)


### PR DESCRIPTION
This commit only adds a `selector_modal_switch.md` file which explains the usage of the _Switch to History_ modal, from `SelectorModal.vue`.

There is another version of `SelectorModal.vue` that takes the boolean prop `multiple`, which changes it into the History Multiview selector (accessible through the button on the top right of the multiview), and we will need to add another `.md` help file for that (named `selector_modal_multiview.md`).

In Galaxy, we will then conditionally fetch the appropriate help `.md` based on the component's prop.