### PR TITLE
Add help text for selector modal in history multiview

### DIFF
--- a/histories/selector_modal_multiview.md
+++ b/histories/selector_modal_multiview.md
@@ -1,0 +1,76 @@
+# [Help] How to use the History Selector
+
+This menu is the **History Selector For Multiview** which allows you to select and **pin** multiple histories to the multiview.
+
+## How to select one or more histories:
+1. **Find the histories** you want to select:
+   - Scroll this menu to the bottom to load more histories and find the ones you are looking for
+   - Find histories using the search field or the filter menu accessible through the toggle button next to the search field
+2. **Click anywhere on the History card** to select an individual history (the modal will not be closed)
+3. You will see your selected histories highlighted and the <code>n histories selected</code> link at the bottom will indicate your selection size
+   - Click that link to reset your selection if needed
+4. Once you have a selection (or your existing selection of histories has changed), you can click on the button at the bottom to **Change Selected** histories
+
+:flashlight: Not enough histories? [Create](https://training.galaxyproject.org/training-material/faqs/galaxy/histories_create_new.html) new histories to see them in this menu.
+
+## :question: Help
+
+<details>
+<summary><b>What happens if I have <i>no histories selected</i>?</b></summary>
+  That is the default behavior and in that case, you are in the <b>Recent Histories Mode</b> where the multiview is "Showing the 4 most recently updated histories. Pin histories to this view by clicking on Select Histories." When in the History Multiview, you can also reset your selection into the <b>Recent Histories Mode</b> by clicking on the button right next to the one that opened this modal titled: <code>fa-clock</code> Recent.
+</details>
+
+<details>
+  <summary><b>Where do I find an exhaustive list of all of my histories?</b></summary>
+  An exhaustive list of all of your histories (and public histories or histories shared with you) can be found in the Histories list accessible by clicking on <b>User > Histories</b> in the masthead on the top, or by clicking on the <b>Histories</b> activity in the activity bar.
+</details>
+
+## Other operations in this menu
+
+On the bottom right corner of each history in this menu, you will find a couple buttons:
+1. The first `fa-sign-in-alt`, titled _"Set as Current History"_ will set that history as your current/active history in the History Panel on the right.
+2. The second `fa-list-alt`, titled _"Open in center panel"_ will open that history in the center, giving you more space to work with the history.
+
+:exclamation: **Neither of these operations will change your Current History**
+
+:flashlight: See a version of this list in your left side panel (if not enabled already) by clicking on the `fa-columns` History Multiview activity in the activity bar.
+
+### Learn
+
+#### Galaxy Tutorials
+
+Tutorials from the _Galaxy Training Network_ that might help:
+
+[History Multiview](https://training.galaxyproject.org/training-material/faqs/galaxy/histories_side_by_side_view.html)
+
+[Understanding Galaxy history system](https://training.galaxyproject.org/training-material/topics/galaxy-interface/tutorials/history/tutorial.html)
+
+[Search the Galaxy Training Network](https://training.galaxyproject.org/training-material/search2)
+
+#### Galaxy FAQs
+
+<details>
+  <summary>Different dataset icons and their usage</summary>
+  display md https://training.galaxyproject.org/training-material/faqs/galaxy/datasets_icons.html
+</details>
+
+<details>
+  <summary>Upload: Getting Data into Galaxy</summary>
+  display md https://help.galaxyproject.org/t/getting-data-into-galaxy/10868
+</details>
+
+<details>
+  <summary>Troubleshooting errors</summary>
+  display md https://training.galaxyproject.org/training-material/faqs/galaxy/analysis_troubleshooting.html
+</details>
+
+[See all Galaxy FAQs](https://training.galaxyproject.org/training-material/faqs/galaxy/)
+
+
+#### Help
+
+Get help navigating Galaxy by visiting the _Galaxy Help Forum_
+
+[Troubleshooting resources for errors or unexpected results](https://help.galaxyproject.org/docs?topic=42)
+
+[Visit the Galaxy Help forum](https://help.galaxyproject.org/)


### PR DESCRIPTION
Another "version" of the help text for the history selector modal; this one shows up when you open the selector in multiview.